### PR TITLE
Use Autoprefixer via PostCSS

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,5 @@
 var ap = require('autoprefixer-core'),
+    postcss = require('postcss'),
     map = require('multi-stage-sourcemap'),
     path = require('path');
 
@@ -38,7 +39,7 @@ module.exports = function(opts) {
       }
 
       // run autoprefixer
-      var res = ap(opts).process(css, process_opts);
+      var res = postcss([ap(opts)]).process(css, process_opts);
 
       // if sourcemaps are generated, combine the two
       if (res.map && style.sourcemap) {

--- a/index.js
+++ b/index.js
@@ -52,6 +52,8 @@ module.exports = function(opts) {
         style.sourcemap = JSON.parse(combined_map);
       }
 
+      res.warnings().forEach(console.error);
+
       // return the css output
       return res.css;
     });

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
   },
   "dependencies": {
     "autoprefixer-core": "5.x",
-    "multi-stage-sourcemap": "0.2.x"
+    "multi-stage-sourcemap": "0.2.x",
+    "postcss": "4.x"
   }
 }


### PR DESCRIPTION
Autoprefixer is currently displaying this warning:

> Autoprefixer's process() method is deprecated and will removed in next major release. Use postcss([autoprefixer]).process() instead

This commit fixes this by using the new method with PostCSS.