### PR TITLE
Update source maps tests

### DIFF
--- a/test/test.coffee
+++ b/test/test.coffee
@@ -37,5 +37,5 @@ describe 'basic', ->
         style.sourcemap.should.be.an('object')
         style.sourcemap.sources[0].should.equal('stylus')
         style.sourcemap.version.should.equal(3)
-        style.sourcemap.mappings.should.equal('AAAA;EACE,sBAAA;EAAA,uBAAA;EAAA,sBAAA;EAAA,eAAA')
+        style.sourcemap.mappings.should.equal('AAAA;EACE,qBAAA;EAAA,sBAAA;EAAA,qBAAA;EAAA,cAAA')
         done()


### PR DESCRIPTION
I'm really not sure about this, I just noticed tests were not passing on master because of the source maps assertion. It's maybe because of a change on Autoprefixer/PostCSS side?

I don't think this new output is bogus, so maybe test case needs an update?