### PR TITLE
Pinned all dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,14 +8,14 @@
     "url": "git://github.com/jenius/autoprefixer-stylus.git"
   },
   "devDependencies": {
-    "chai": "1.x",
-    "coffee-script": "1.8.x",
-    "coveralls": "2.x",
-    "css-parse": "2.x",
-    "istanbul": "0.3.x",
-    "mocha": "2.x",
+    "chai": "1.10.0",
+    "coffee-script": "1.8.0",
+    "coveralls": "2.11.4",
+    "css-parse": "2.0.0",
+    "istanbul": "0.3.21",
+    "mocha": "2.3.3",
     "mocha-lcov-reporter": "0.0.1",
-    "stylus": "latest"
+    "stylus": "0.52.4"
   },
   "author": "Jeff Escalante",
   "main": "index.js",
@@ -28,8 +28,8 @@
     "node": ">=0.8.0"
   },
   "dependencies": {
-    "autoprefixer": "6.x",
-    "multi-stage-sourcemap": "0.2.x",
-    "postcss": "5.x"
+    "autoprefixer": "6.0.3",
+    "multi-stage-sourcemap": "0.2.1",
+    "postcss": "5.0.8"
   }
 }


### PR DESCRIPTION
:wave: Hello!

We’re all trying to keep our software up to date, yet stable at the same time.

This is the first in a series of automatic PRs to help you achieve this goal. It pins all of the dependencies in your `package.json`, so you have complete control over the exact state of your software.

From now on you’ll receive PRs whenever one of your dependencies updates – in real time. This way you get all the benefits of up-to-date dependencies, while having them pinned at the same time. This means:

- No more surprises because some of your dependencies didn’t follow [SemVer](http://semver.org/). Your software is always in a state you know about, regardless of _when_ someone does `$ npm install`.
- If you have continuous integration set up for this repo, it’ll run automatically. Ideally, it will pass and you'll stay up to date with the press of a button. If the updated dependency _does_ break your software, it won’t affect your users, because their dependencies are still pinned to the working state.
- You can immediately identify which dependency updates break your software, because each one is tested in isolation. You’ll also have a branch ready to work on, so adapting to new APIs is way faster.

Merge this PR and you’ll have up-to-date software without the headaches :sparkles:

---

This pull request was created by [greenkeeper.io](http://greenkeeper.io/).
It keeps your software, up to date, all the time.

<sub>
Tired of seeing this sponsor message? Upgrade to the supporter plan!
You'll also get your pull requests faster :zap:
</sub>