### PR TITLE
Update README URLs based on HTTP redirects

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,12 +1,12 @@
 Autoprefixer Stylus
 -------------------
 
-An [autoprefixer](https://github.com/ai/autoprefixer) plugin for stylus.
+An [autoprefixer](https://github.com/postcss/autoprefixer) plugin for stylus.
 
-[![npm](http://img.shields.io/npm/v/autoprefixer-stylus.svg?style=flat)](http://badge.fury.io/js/autoprefixer-stylus)
-[![tests](http://img.shields.io/travis/jenius/autoprefixer-stylus/master.svg?style=flat)](https://travis-ci.org/jenius/autoprefixer-stylus)
-[![coverage](http://img.shields.io/coveralls/jenius/autoprefixer-stylus/master.svg?style=flat)](https://coveralls.io/r/jenius/autoprefixer-stylus)
-[![dependencies](http://img.shields.io/gemnasium/jenius/autoprefixer-stylus.svg?style=flat)](https://gemnasium.com/jenius/autoprefixer-stylus)
+[![npm](https://img.shields.io/npm/v/autoprefixer-stylus.svg?style=flat)](http://badge.fury.io/js/autoprefixer-stylus)
+[![tests](https://img.shields.io/travis/jenius/autoprefixer-stylus/master.svg?style=flat)](https://travis-ci.org/jenius/autoprefixer-stylus)
+[![coverage](https://img.shields.io/coveralls/jenius/autoprefixer-stylus/master.svg?style=flat)](https://coveralls.io/r/jenius/autoprefixer-stylus)
+[![dependencies](https://img.shields.io/gemnasium/jenius/autoprefixer-stylus.svg?style=flat)](https://gemnasium.com/jenius/autoprefixer-stylus)
 
 ### Installation
 


### PR DESCRIPTION
Created with https://github.com/dkhamsing/frankenstein

### GitHub Corrected URLs 
Was | Now 
--- | --- 
https://github.com/ai/autoprefixer | https://github.com/postcss/autoprefixer 


### HTTPS Corrected URLs 
Was | Now 
--- | --- 
http://img.shields.io/coveralls/jenius/autoprefixer-stylus/master.svg?style=flat | https://img.shields.io/coveralls/jenius/autoprefixer-stylus/master.svg?style=flat 
http://img.shields.io/gemnasium/jenius/autoprefixer-stylus.svg?style=flat | https://img.shields.io/gemnasium/jenius/autoprefixer-stylus.svg?style=flat 
http://img.shields.io/npm/v/autoprefixer-stylus.svg?style=flat | https://img.shields.io/npm/v/autoprefixer-stylus.svg?style=flat 
http://img.shields.io/travis/jenius/autoprefixer-stylus/master.svg?style=flat | https://img.shields.io/travis/jenius/autoprefixer-stylus/master.svg?style=flat 
